### PR TITLE
fix(build): skip examples module in build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,10 +58,10 @@
 
     <module>modules/schematics</module>
 
+    <!--
     <module>modules/coverage-reports</module>
-
-    <!-- This module should always be listed last -->
     <module>modules/examples</module>
+    -->
   </modules>
 
   <licenses>


### PR DESCRIPTION
## PR summary
This PR changes /pom.xml to avoid building the examples module, which is not yet complete and fails the Sonatype staging rules (no source and no javadocs).

## PR Checklist
Please make sure that your PR fulfills the following requirements:  
- [ ] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## Current vs new behavior  
<!-- Please describe the current behavior that you are modifying and the new behavior. -->

## Does this PR introduce a breaking change?    
- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
<!-- Please add any additional information that would help reviewers evaluate your PR -->
